### PR TITLE
Fix broken do_install()

### DIFF
--- a/recipes/nodejs/nodejs_0.10.inc
+++ b/recipes/nodejs/nodejs_0.10.inc
@@ -35,7 +35,7 @@ do_compile () {
 }
 
 do_install () {
-  DESTDIR=${D} oe_runmake install
+  oe_runmake DESTDIR=${D} install
 }
 
 RDEPENDS_${PN} = "zlib openssl curl python-compiler python-shell python-datetime python-subprocess python-multiprocessing python-crypt python-textutils python-netclient python-misc"


### PR DESCRIPTION
Setting an environment variable before the call to a Bash function
like oe_runmake() does not (always?) work as expected. Need to provide
the DESTDIR variable as a command-line argument.

Fixes #1
