### PR TITLE
Close #3: Use virtual package name "node" in RPROVIDES

### DIFF
--- a/recipes/nodejs/nodejs_0.10.inc
+++ b/recipes/nodejs/nodejs_0.10.inc
@@ -41,7 +41,7 @@ do_install () {
 
 PROVIDES = "virtual/node"
 
-RPROVIDES_${PN} = "virtual/node"
+RPROVIDES_${PN} = "node"
 
 RCONFLICTS_${PN} = "iojs"
 

--- a/recipes/nodejs/nodejs_0.12.inc
+++ b/recipes/nodejs/nodejs_0.12.inc
@@ -41,7 +41,7 @@ do_install () {
 
 PROVIDES = "virtual/node"
 
-RPROVIDES_${PN} = "virtual/node"
+RPROVIDES_${PN} = "node"
 
 RCONFLICTS_${PN} = "iojs"
 


### PR DESCRIPTION
`RPROVIDES` specifies the provided virtual packages in the sense of
a package management system (ipk, deb or rpm) that a recipe provides.
Thus it does not need the "virtual/" prefix that is often used in
`PROVIDES`.
