### PR TITLE
npm.bbclass should refer to node in it's RDEPENDS appending

### DIFF
--- a/classes/npm.bbclass
+++ b/classes/npm.bbclass
@@ -1,6 +1,6 @@
 DEPENDS += " virtual/node-native"
 
-RDEPENDS_${PN} += " virtual/node"
+RDEPENDS_${PN} += " node"
 
 PACKAGE_DEBUG_SPLIT_STYLE = "debug-file-directory"
 


### PR DESCRIPTION
Otherwise bitbake complains that nothing RPROVIDES  virtual/node.
