### PR TITLE
Make use of http_proxy and https_proxy in bitbake environment

### DIFF
--- a/classes/npm.bbclass
+++ b/classes/npm.bbclass
@@ -7,7 +7,7 @@ PACKAGE_DEBUG_SPLIT_STYLE = "debug-file-directory"
 NPM = "npm"
 NPM_CACHE_DIR = "${WORKDIR}/npm_cache"
 NPM_ARCHFLAGS += "--arch=${TARGET_ARCH} --target_arch=${TARGET_ARCH}"
-NPM_FLAGS ?= ""	
+NPM_FLAGS ?= "--https-proxy=${https_proxy} --proxy=${http_proxy} "
 CCACHE = ""
 
 oe_runnpm() {


### PR DESCRIPTION
Add default https-proxy and proxy flags to NPM_FLAGS to forward on bitbakes usage of http_proxy and https_proxy.

Unless there is an easier location we should be doing this in? This is just a quick way to keep the npm proxy configuration within bitbake and not rely on external settings that I found while working from behind a corporate proxy. Trash this pull request if there is an easier way that I didn't notice or if there is a nicer way to implement. 
