### PR TITLE
Enable multi-core build

### DIFF
--- a/classes/npm.bbclass
+++ b/classes/npm.bbclass
@@ -30,6 +30,8 @@ oe_runnpm() {
 
 	bbnote ${NPM} --arch=${NPM_ARCH} --target_arch=${NPM_ARCH} ${NPM_FLAGS} "$@"
 
+	export JOBS=${@oe.utils.cpu_count()}
+
 	LD="${NPM_LD}" ${NPM} --arch=${NPM_ARCH} --target_arch=${NPM_ARCH} ${NPM_FLAGS} "$@" || die "oe_runnpm failed"
 
 }
@@ -57,6 +59,8 @@ oe_runnpm_native() {
 	bbnote NPM HTTPS proxy: ${NPM_CONFIG_HTTPS_PROXY}
 
 	bbnote ${NPM_NATIVE} --arch=${NPM_ARCH_NATIVE} --target_arch=${NPM_ARCH_NATIVE} ${NPM_FLAGS_NATIVE} "$@"
+
+	export JOBS=${@oe.utils.cpu_count()}
 
 	LD="${NPM_LD_NATIVE}" ${NPM_NATIVE} --arch=${NPM_ARCH_NATIVE} --target_arch=${NPM_ARCH_NATIVE} ${NPM_FLAGS_NATIVE} "$@" || die "oe_runnpm_native failed"
 

--- a/recipes/nodejs/nodejs0.inc
+++ b/recipes/nodejs/nodejs0.inc
@@ -46,7 +46,7 @@ do_configure () {
 do_compile () {
   export LD="${CXX}"
   alias g++="${CXX}"
-  make BUILDTYPE=Release
+  make -j ${@oe.utils.cpu_count()} BUILDTYPE=Release
   unalias g++
 }
 

--- a/recipes/nodejs/nodejs0.inc
+++ b/recipes/nodejs/nodejs0.inc
@@ -46,7 +46,7 @@ do_configure () {
 do_compile () {
   export LD="${CXX}"
   alias g++="${CXX}"
-  make -j ${@oe.utils.cpu_count()} BUILDTYPE=Release
+  make ${PARALLEL_MAKE} BUILDTYPE=Release
   unalias g++
 }
 

--- a/recipes/nodejs/nodejs4.inc
+++ b/recipes/nodejs/nodejs4.inc
@@ -41,7 +41,7 @@ do_configure () {
 do_compile () {
   export LD="${CXX}"
   alias g++="${CXX}"
-  make BUILDTYPE=Release
+  make -j ${@oe.utils.cpu_count()} BUILDTYPE=Release
   unalias g++
 }
 

--- a/recipes/nodejs/nodejs4.inc
+++ b/recipes/nodejs/nodejs4.inc
@@ -41,7 +41,7 @@ do_configure () {
 do_compile () {
   export LD="${CXX}"
   alias g++="${CXX}"
-  make -j ${@oe.utils.cpu_count()} BUILDTYPE=Release
+  make ${PARALLEL_MAKE} BUILDTYPE=Release
   unalias g++
 }
 

--- a/recipes/nodejs/nodejs5.inc
+++ b/recipes/nodejs/nodejs5.inc
@@ -41,7 +41,7 @@ do_configure () {
 do_compile () {
   export LD="${CXX}"
   alias g++="${CXX}"
-  make BUILDTYPE=Release
+  make -j ${@oe.utils.cpu_count()} BUILDTYPE=Release
   unalias g++
 }
 

--- a/recipes/nodejs/nodejs5.inc
+++ b/recipes/nodejs/nodejs5.inc
@@ -41,7 +41,7 @@ do_configure () {
 do_compile () {
   export LD="${CXX}"
   alias g++="${CXX}"
-  make -j ${@oe.utils.cpu_count()} BUILDTYPE=Release
+  make ${PARALLEL_MAKE} BUILDTYPE=Release
   unalias g++
 }
 


### PR DESCRIPTION
This commit enables utilization of all available cores on
multi-core machines. It speeds up node-js compilation, as
well as improves `npm install` command to use multi job
switch when compiling node add-ons using node-gyp.
