### PR TITLE
Add support for bower package manager

### DIFF
--- a/classes/bower-install.bbclass
+++ b/classes/bower-install.bbclass
@@ -1,0 +1,12 @@
+inherit bower
+
+B="${S}"
+
+BOWER_INSTALL ?= ""
+BOWER_INSTALL_FLAGS ?= ""
+
+do_bower_install() {
+	oe_runbower ${BOWER_INSTALL_FLAGS} install ${BOWER_INSTALL}
+}
+
+addtask bower_install after do_npm_dedupe before do_install

--- a/classes/bower.bbclass
+++ b/classes/bower.bbclass
@@ -1,0 +1,18 @@
+DEPENDS += " bower"
+
+RDEPENDS_${PN} += " node"
+
+PACKAGE_DEBUG_SPLIT_STYLE = "debug-file-directory"
+
+BOWER ?= "bower"
+BOWER_FLAGS ?= ""
+
+# Target bower
+
+oe_runbower() {
+
+	bbnote ${BOWER} ${BOWER_FLAGS} "$@"
+
+	${BOWER} ${BOWER_FLAGS} "$@" || die "oe_runbower failed"
+
+}

--- a/recipes/bower/bower_1.6.8.bb
+++ b/recipes/bower/bower_1.6.8.bb
@@ -1,0 +1,16 @@
+SUMMARY = "Bower package manager"
+HOMEPAGE = "http://bower.io"
+SECTION = "js/devel"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=135697567327f92e904ef0be2082da5e"
+
+PACKAGE_ARCH = "all"
+
+SRC_URI = "https://github.com/bower/bower/archive/v${PV}.tar.gz"
+
+SRC_URI[md5sum] = "01ad5587621e5611ec3dbdc4955cf81b"
+SRC_URI[sha256sum] = "39f471dde25bcce9af9ab4d59d971ab1dffff02a0ebae03fde7a644d49326a6a"
+
+inherit npm-install-global
+
+RDEPENDS_${PN} += " bash"


### PR DESCRIPTION
Hi,

This commit integrates bower support into meta-nodejs. Let me know if it is of any interest. Any comments/suggestions are welcome !

---

Bower is a package manager for front-end dependencies: see http://bower.io

Suppose a software package has some front-end dependencies which are described in
file bower.json. In this case the recipe can auto-install all those dependencies during
yocto build by inheriting bower-install class.

Note that front-end dependencies are auto-installed into build directory. They have to be
explicitely copied into target image in do_install or do_install_append.

Here is a simple example of web app recipe with nodejs and bower dependencies:

---

SUMMARY = "simple web app with js deps described in bower.json"
LICENSE = "MIT"
LIC_FILES_CHKSUM = "file://${COREBASE}/LICENSE;md5=4d92cd373abda3937c2bc47fbc49d690"

SRCREV = "${AUTOREV}"

PR = "r0"
PV = "0.0.1+git${SRCPV}"

SRC_URI = "git://path/to/git/repo/test.git;branch=master;protocol=ssh"

inherit npm-install bower-install

S = "${WORKDIR}/git"

do_install () {
    install -d ${D}/www/test
    install -d ${D}/www/test/public

```
install -m 0644 ${S}/simple.node.js ${D}/www/test/simple.node.js
install -m 0644 ${S}/public/index.html ${D}/www/simple/public/index.html

cp -r ${S}/node_modules ${D}/www/test/
cp -r ${S}/public/bower_components ${D}/www/test/public/
```
## }

Signed-off-by: Sergey Matyukevich geomatsi@gmail.com
