### PR TITLE
Add PACKAGECONFIG options to allow building nodejs with shared openss…

### DIFF
--- a/recipes/nodejs/nodejs4.inc
+++ b/recipes/nodejs/nodejs4.inc
@@ -32,6 +32,8 @@ ARCHFLAGS ?= ""
 
 GYP_DEFINES_append_mipsel = " mips_arch_variant='r1' "
 
+PACKAGECONFIG[zlib] = "--shared-zlib,,zlib"
+PACKAGECONFIG[openssl] = "--shared-openssl,,openssl"
 
 do_configure () {
   export LD="${CXX}"
@@ -40,7 +42,8 @@ do_configure () {
   ./configure 	--prefix="${prefix}" \
 		--dest-cpu="${@map_dest_cpu(d.getVar('TARGET_ARCH', True), d)}" \
 		--dest-os=linux ${ARCHFLAGS} \
-		--without-snapshot
+		--without-snapshot \
+		${EXTRA_OECONF}
   unalias g++
 }
 


### PR DESCRIPTION
…l and zlib

This allows consumers to activate the usage of shared libraries easily in
a bbappend using PACKAGECONFIG = "zlib openssl".
