### PR TITLE
nodejs: Remove --disable-static and fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,9 @@ You can disable one or more of these build tasks in the recipe with `do_<tasknam
  * `NPM_INSTALL_FLAGS`: Extra command line arguments for `npm` calls made in `npm_install` task 
  * `NPM_INSTALL`: Parameters for `npm install` command (such as specific package names)
 
-## `npm-global-install` class
+## `npm-install-global` class
 
-`npm-global-install` class inherits `npm` class and installs the selected package globally.
+`npm-install-global` class inherits `npm` class and installs the selected package globally.
 This is done in the `do_install` task of the class.
 
 ### Variables

--- a/recipes/nodejs/nodejs_4.inc
+++ b/recipes/nodejs/nodejs_4.inc
@@ -36,6 +36,8 @@ GYP_DEFINES_append_mipsel = " mips_arch_variant='r1' "
 PACKAGECONFIG[zlib] = "--shared-zlib,,zlib"
 PACKAGECONFIG[openssl] = "--shared-openssl,,openssl"
 
+DISABLE_STATIC = ""
+
 do_configure () {
   export LD="${CXX}"
   alias g++="${CXX}"


### PR DESCRIPTION
latest oe-core/master will now pass --disable-static
by default, but nodejs errors out

| Usage: configure [options]
|
| configure: error: no such option: --disable-static
| WARNING: exit code 2 from a shell command.

Lets weed out this option from EXTRA_OECONF

Signed-off-by: Khem Raj raj.khem@gmail.com
