### PR TITLE
Add armv5 to list of compatible machine for nodejs_6

### DIFF
--- a/recipes-devtools/nodejs/nodejs_6.inc
+++ b/recipes-devtools/nodejs/nodejs_6.inc
@@ -4,7 +4,7 @@ HOMEPAGE = "http://nodejs.org"
 LICENSE = "MIT"
 
 COMPATIBLE_MACHINE_armv4 = "(!.*armv4).*"
-COMPATIBLE_MACHINE_armv5 = "(!.*armv5).*"
+# COMPATIBLE_MACHINE_armv5 = "(!.*armv5).*"
 COMPATIBLE_MACHINE_mips64 = "(!.*mips64).*"
 
 INC_PR = "r1"


### PR DESCRIPTION
We can confirm that node.js 6 work fine with few ARMv5 configurations, not all of them as my colleague mentioned, ref: https://github.com/nodejs/node/blob/master/deps/v8/src/base/atomicops_internals_arm_gcc.h#L159-L161
