### PR TITLE
npm-base: Add support for no_proxy

### DIFF
--- a/classes/npm-base.bbclass
+++ b/classes/npm-base.bbclass
@@ -38,6 +38,7 @@ oe_runnpm() {
 
 	export http_proxy="${http_proxy}"
 	export https_proxy="${https_proxy}"
+	export no_proxy="${no_proxy}"
 
 	LD="${NPM_LD}" ${NPM} --registry=${NPM_REGISTRY} ${ARCH_FLAGS} ${NPM_FLAGS} "$@" || die "oe_runnpm failed"
 
@@ -73,6 +74,7 @@ oe_runnpm_native() {
 
 	export http_proxy="${http_proxy}"
 	export https_proxy="${https_proxy}"
+	export no_proxy="${no_proxy}"
 
 	LD="${NPM_LD_NATIVE}" ${NPM_NATIVE} --registry=${NPM_REGISTRY} ${ARCH_FLAGS} ${NPM_FLAGS_NATIVE} "$@" || die "oe_runnpm_native failed"
 


### PR DESCRIPTION
Exports no_proxy environment variable in addition to http_proxy.
