### PR TITLE
nodejs: switch from EXTRA_OECONF to PACKAGECONFIG_CONFARGS in configure

### DIFF
--- a/recipes-devtools/nodejs/nodejs_4.inc
+++ b/recipes-devtools/nodejs/nodejs_4.inc
@@ -40,7 +40,7 @@ do_configure () {
 		--dest-cpu="${@nodejs_map_dest_cpu(d.getVar('TARGET_ARCH', True), d)}" \
 		--dest-os=linux ${ARCHFLAGS} \
 		--without-snapshot \
-		${EXTRA_OECONF}
+		${PACKAGECONFIG_CONFARGS}
   unalias g++
 }
 

--- a/recipes-devtools/nodejs/nodejs_6.inc
+++ b/recipes-devtools/nodejs/nodejs_6.inc
@@ -47,7 +47,7 @@ do_configure () {
 		--dest-os=linux ${ARCHFLAGS} \
 		--without-snapshot \
 		--with-intl=none \
-		${EXTRA_OECONF}
+		${PACKAGECONFIG_CONFARGS}
 }
 
 do_compile () {


### PR DESCRIPTION
Arguments from PACKAGECONFIG only get appended to EXTRA_OECONF if the
autotools class is inherited in the recipe. As this is not the case
with the node recipes, the PACKAGECONFIG settings never make it into the
build. Switch to directly using the PACKAGECONFIG_CONFARGS variable to
the right arguments get passed through.
