### PR TITLE
Node.js:  Add compatibility with base OpenEmbedded npm.bbclass

### DIFF
--- a/recipes-devtools/nodejs/files/no-registry.patch
+++ b/recipes-devtools/nodejs/files/no-registry.patch
@@ -1,0 +1,59 @@
+Bugfix for --no-registry in nodejs-v0.12.2
+
+diff -u -r node-v0.12.2_def/deps/npm/lib/cache/caching-client.js node-v0.12.2/deps/npm/lib/cache/caching-client.js
+--- node-v0.12.2_def/deps/npm/lib/cache/caching-client.js	2015-04-01 01:13:01.000000000 +0300
++++ node-v0.12.2/deps/npm/lib/cache/caching-client.js	2015-05-18 00:47:10.738599686 +0300
+@@ -67,6 +67,22 @@
+   var cacheBase = cacheFile(npm.config.get("cache"))(uri)
+   var cachePath = path.join(cacheBase, ".cache.json")
+ 
++  if (parsed.host === "noregistry") (function() {
++    var stat = null
++    var file = npm.config.get("cache") + parsed.pathname + "/.cache.json"
++    try {
++      stat = fs.statSync(cachePath)
++    } catch (ex) {}
++    if (!stat) try {
++      stat = fs.statSync(file) 
++      cachePath = file
++    } catch (ex) {
++      stat = "Registry not defined and registry files not found: \"" +
++             cachePath + "\", \"" + file + "\"."
++      throw new Error(stat)
++    }
++  })()
++
+   // If the GET is part of a write operation (PUT or DELETE), then
+   // skip past the cache entirely, but still save the results.
+   if (uri.match(/\?write=true$/)) {
+@@ -83,12 +99,17 @@
+         }
+         catch (ex) {
+           data = null
++          if (parsed.host === "noregistry")
++            throw new Error("File \"" + cachePath+"\"" + " corrupted.")
+         }
+ 
+         params.stat = stat
+         params.data = data
+ 
+-        get_.call(client, uri, cachePath, params, cb)
++        if (parsed.host === "noregistry")
++          cb(null, data, JSON.stringify(data), { statusCode : 304 })
++        else
++          get_.call(client, uri, cachePath, params, cb)
+       })
+     }
+     else {
+diff -u -r node-v0.12.2_def/deps/npm/lib/utils/map-to-registry.js node-v0.12.2/deps/npm/lib/utils/map-to-registry.js
+--- node-v0.12.2_def/deps/npm/lib/utils/map-to-registry.js	2015-04-01 01:13:01.000000000 +0300
++++ node-v0.12.2/deps/npm/lib/utils/map-to-registry.js	2015-05-18 01:15:10.030569613 +0300
+@@ -45,6 +45,8 @@
+ 
+   log.silly("mapToRegistry", "registry", registry)
+ 
++  if (!registry) return cb(null, "http://noregistry/" + name, {})
++
+   var auth = config.getCredentialsByURI(registry)
+ 
+   // normalize registry URL so resolution doesn't drop a piece of registry URL

--- a/recipes-devtools/nodejs/files/no-registry_6.x.patch
+++ b/recipes-devtools/nodejs/files/no-registry_6.x.patch
@@ -1,0 +1,49 @@
+diff -Naur node-v6.10.0/deps/npm/lib/cache/caching-client.js node-v6.10.0b/deps/npm/lib/cache/caching-client.js
+--- node-v6.10.0/deps/npm/lib/cache/caching-client.js	2017-02-21 18:40:14.000000000 -0600
++++ node-v6.10.0b/deps/npm/lib/cache/caching-client.js	2017-04-18 14:35:05.725921973 -0500
+@@ -68,6 +68,22 @@
+   var cacheBase = cacheFile(npm.config.get('cache'))(uri)
+   var cachePath = path.join(cacheBase, '.cache.json')
+
++  if (parsed.host === "noregistry") (function() {
++    var stat = null
++    var file = npm.config.get("cache") + parsed.pathname + "/.cache.json"
++    try {
++       stat = fs.statSync(cachePath)
++     } catch (ex) {}
++     if (!stat) try {
++       stat = fs.statSync(file)
++       cachePath = file
++     } catch (ex) {
++       stat = "Registry not defined and registry files not found: \"" +
++              cachePath + "\", \"" + file + "\"."
++       throw new Error(stat)
++     }
++  })()
++
+   // If the GET is part of a write operation (PUT or DELETE), then
+   // skip past the cache entirely, but still save the results.
+   if (uri.match(/\?write=true$/)) {
+@@ -88,7 +104,10 @@
+         params.stat = stat
+         params.data = data
+
+-        get_.call(client, uri, cachePath, params, cb)
++        if (parsed.host === "noregistry")
++           cb(null, data, JSON.stringify(data), { statusCode : 304 })
++        else
++           get_.call(client, uri, cachePath, params, cb)
+       })
+     } else {
+       get_.call(client, uri, cachePath, params, cb)
+diff -Naur node-v6.10.0/deps/npm/lib/utils/map-to-registry.js node-v6.10.0b/deps/npm/lib/utils/map-to-registry.js
+--- node-v6.10.0/deps/npm/lib/utils/map-to-registry.js	2017-02-21 18:40:14.000000000 -0600
++++ node-v6.10.0b/deps/npm/lib/utils/map-to-registry.js	2017-04-18 14:38:29.640908067 -0500
+@@ -45,6 +45,7 @@
+
+   log.silly('mapToRegistry', 'registry', registry)
++   if (!registry) return cb(null, "http://noregistry/" + name, {})
+
+   var auth = config.getCredentialsByURI(registry)
+
+   // normalize registry URL so resolution doesn't drop a piece of registry URL

--- a/recipes-devtools/nodejs/nodejs_4.inc
+++ b/recipes-devtools/nodejs/nodejs_4.inc
@@ -4,12 +4,13 @@ HOMEPAGE = "http://nodejs.org"
 LICENSE = "MIT"
 
 INC_PR = "r1"
-PR = "${INC_PR}.6"
+PR = "${INC_PR}.7"
 
 PROVIDES = "node"
 RPROVIDES_${PN} = "node"
 
-SRC_URI = "https://nodejs.org/dist/v${PV}/node-v${PV}.tar.gz;name=src"
+SRC_URI = "https://nodejs.org/dist/v${PV}/node-v${PV}.tar.gz;name=src \
+           file://no-registry.patch"
 
 S = "${WORKDIR}/node-v${PV}"
 

--- a/recipes-devtools/nodejs/nodejs_6.inc
+++ b/recipes-devtools/nodejs/nodejs_6.inc
@@ -8,12 +8,13 @@ COMPATIBLE_MACHINE_armv4 = "(!.*armv4).*"
 COMPATIBLE_MACHINE_mips64 = "(!.*mips64).*"
 
 INC_PR = "r1"
-PR = "${INC_PR}.7"
+PR = "${INC_PR}.8"
 
 PROVIDES = "node"
 RPROVIDES_${PN} = "node"
 
-SRC_URI = "https://nodejs.org/dist/v${PV}/node-v${PV}.tar.gz;name=src"
+SRC_URI = "https://nodejs.org/dist/v${PV}/node-v${PV}.tar.gz;name=src \
+           file://no-registry_6.x.patch"
 
 S = "${WORKDIR}/node-v${PV}"
 

--- a/recipes-devtools/nodejs/nodejs_7.inc
+++ b/recipes-devtools/nodejs/nodejs_7.inc
@@ -8,12 +8,13 @@ COMPATIBLE_MACHINE_armv4 = "(!.*armv4).*"
 COMPATIBLE_MACHINE_mips64 = "(!.*mips64).*"
 
 INC_PR = "r1"
-PR = "${INC_PR}.2"
+PR = "${INC_PR}.3"
 
 PROVIDES = "node"
 RPROVIDES_${PN} = "node"
 
-SRC_URI = "https://nodejs.org/dist/v${PV}/node-v${PV}.tar.gz;name=src"
+SRC_URI = "https://nodejs.org/dist/v${PV}/node-v${PV}.tar.gz;name=src \
+           file://no-registry_6.x.patch"
 
 S = "${WORKDIR}/node-v${PV}"
 


### PR DESCRIPTION
This patch enables the --no-registry functionality to allow for offline
builds with new nodejs versions.

Signed-off-by: Michael Davis <michael.davis@essvote.com>