### PR TITLE
2017-07-11, Version 6.11.1 'Boron' (LTS)

### DIFF
--- a/recipes-devtools/nodejs/nodejs_6.10.3.bb
+++ b/recipes-devtools/nodejs/nodejs_6.10.3.bb
@@ -1,9 +1,0 @@
-require nodejs_6.inc
-require nodejs_lts.inc
-
-INC_PR = "r1"
-
-LIC_FILES_CHKSUM = "file://LICENSE;md5=41a3a0ccf7f515cac3377389dd8faac8"
-
-SRC_URI[src.md5sum] = "73982a158e4f05d36c01b7a97e38da18"
-SRC_URI[src.sha256sum] = "a8f679f595fd921305c28d126935ad59b4419ac8474a99997a31e01ab50acd3d"

--- a/recipes-devtools/nodejs/nodejs_6.11.1.bb
+++ b/recipes-devtools/nodejs/nodejs_6.11.1.bb
@@ -1,0 +1,8 @@
+require nodejs_6.inc
+
+INC_PR = "r1"
+
+LIC_FILES_CHKSUM = "file://LICENSE;md5=41a3a0ccf7f515cac3377389dd8faac8"
+
+SRC_URI[src.md5sum] = "9f43c072bc2940ba0bde21646e8012f9"
+SRC_URI[src.sha256sum] = "0187d4e4ef00cee2b70b0ad0689100050654f26629775d097b145d0d8727f9a0"


### PR DESCRIPTION
I've been made aware by @petrosagg that meta-nodejs builds are done without snapshots so the hashseed vulnerability doesn't affect them, but it's still nice to have the latest version.

```
Notable changes:
* build:
  - Disable V8 snapshots - The hashseed embedded in the snapshot is currently the same for all runs of the binary. This opens node up to collision attacks which could result in a Denial of Service. We have temporarily disabled snapshots until a more robust solution is found (Ali Ijaz Sheikh)
* deps:
  - CVE-2017-1000381 - The c-ares function ares_parse_naptr_reply(), which is used for parsing NAPTR responses, could be triggered to read memory outside of the given input buffer if the passed in DNS response packet was crafted in a particular way. This patch checks that there is enough data for the required elements of an NAPTR record (2 int16, 3 bytes for string lengths) before processing a record. (David Drysdale)

Notable changes (6.11.0):

* build:
  - support for building mips64el (nanxiongchao) #10991
* cluster:
  - disconnect() now returns a reference to the disconnected worker. (Sean Villars) #10019
* crypto:
  - ability to select cert store at runtime (Adam Majer) #8334
  - Use system CAs instead of using bundled ones (Adam Majer) #8334
  - The Decipher methods setAuthTag() and setAAD now return this. (Kirill Fomichev) #9398
  - adding support for OPENSSL_CONF again (Sam Roberts) #11006
  - make LazyTransform compabile with Streams1 (Matteo Collina) #12380
* deps:
  - upgrade libuv to 1.11.0 (cjihrig) #11094
  - upgrade libuv to 1.10.2 (cjihrig) #10717
  - upgrade libuv to 1.10.1 (cjihrig) #9647
  - upgrade libuv to 1.10.0 (cjihrig) #9267
* dns:
  - Implemented {ttl: true} for resolve4() and resolve6(). (Ben Noordhuis) #9296
* process:
  - add NODE_NO_WARNINGS environment variable (cjihrig) #10842
* readline:
  - add option to stop duplicates in history (Danny Nemer) #2982
* src:
  - support "--" after "-e" as end-of-options (John Barboza) #10651
* tls:
  - new tls.TLSSocket() supports sec ctx options (Sam Roberts) #11005
  - Allow obvious key/passphrase combinations. (Sam Roberts) #10294
```

Signed-off-by: Pablo Carranza Velez <pablo@resin.io>