### PR TITLE
layer.conf: Define LAYERSERIES_COMPAT to avoid build warnings

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,3 +9,5 @@ BBFILE_PATTERN_nodejs := "^${LAYERDIR}/"
 BBFILE_PRIORITY_nodejs = "45"
 
 LAYERDEPENDS_nodejs = "core"
+
+LAYERSERIES_COMPAT_nodejs = "sumo thud"


### PR DESCRIPTION
Signed-off-by: Andrei Gherzan <andrei@balena.io>